### PR TITLE
Implement `Brand` to product structured data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2022-02-02
+### Added
+- Make it possible to set a [Brand](https://schema.org/Brand) for products
+
+### Remove
+- Remove `@cover` from test docblocks
+
 ## [1.1.0] - 2022-02-02
 ### Changed
 - Added requirements to allow adding the extension to Magento 2.3.7-p1

--- a/src/ViewModel/Schema/AbstractSchema.php
+++ b/src/ViewModel/Schema/AbstractSchema.php
@@ -11,12 +11,13 @@ use Magento\Store\Model\ScopeInterface;
 
 abstract class AbstractSchema implements SchemaInterface, ArgumentInterface
 {
-    protected const SCHEMA_CONTEXT   = 'https://schema.org/',
+    public const SCHEMA_CONTEXT      = 'https://schema.org/',
         SCHEMA_TYPE_ORGANIZATION     = 'Organization',
         SCHEMA_TYPE_POSTAL_ADDRESS   = 'PostalAddress',
         SCHEMA_TYPE_WEBSITE          = 'WebSite',
         SCHEMA_TYPE_SEARCH_ACTION    = 'SearchAction',
         SCHEMA_TYPE_PRODUCT          = 'Product',
+        SCHEMA_TYPE_BRAND            = 'Brand',
         SCHEMA_TYPE_OFFER            = "Offer",
         SCHEMA_TYPE_REVIEW           = 'Review',
         SCHEMA_TYPE_RATING           = 'Rating',

--- a/src/ViewModel/Schema/Product.php
+++ b/src/ViewModel/Schema/Product.php
@@ -22,7 +22,8 @@ use Magento\Store\Model\StoreManagerInterface;
 
 class Product extends AbstractSchema
 {
-    public const XML_PATH_GTIN_ATTRIBUTE = 'structured_data/product/gtin',
+    public const XML_PATH_ATTRIBUTE_GTIN = 'structured_data/product/gtin',
+        XML_PATH_ATTRIBUTE_BRAND         = 'structured_data/product/brand',
         XML_PATH_REVIEW_LIMIT            = 'structured_data/product/review_limit',
         RATINGS_BEST_RATING              = 5,
         SCHEMA_AVAILABILITY_IN_STOCK     = 'https://schema.org/InStock',
@@ -93,11 +94,19 @@ class Product extends AbstractSchema
             ]
         ];
 
-        $attributeCode = $this->getGtinAttribute();
-        $reviews       = $this->getProductReviews($product);
+        $gtinAttribute  = $this->getProductAttribute(self::XML_PATH_ATTRIBUTE_GTIN);
+        $brandAttribute = $this->getProductAttribute(self::XML_PATH_ATTRIBUTE_BRAND);
+        $reviews        = $this->getProductReviews($product);
 
-        if ($attributeCode) {
-            $data['gtin'] = $product->getData($attributeCode);
+        if ($gtinAttribute) {
+            $data['gtin'] = $product->getData($gtinAttribute);
+        }
+
+        if ($brandAttribute) {
+            $data['brand'] = [
+                '@type' => self::SCHEMA_TYPE_BRAND,
+                'name' => $product->getData($brandAttribute)
+            ];
         }
 
         if ($reviews->getSize()) {
@@ -134,10 +143,10 @@ class Product extends AbstractSchema
             ->getUrl();
     }
 
-    private function getGtinAttribute(): ?string
+    private function getProductAttribute(string $attribute): ?string
     {
         return $this->scopeConfig->getValue(
-            self::XML_PATH_GTIN_ATTRIBUTE,
+            $attribute,
             ScopeInterface::SCOPE_STORE
         );
     }

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -46,6 +46,10 @@
                     <source_model>Elgentos\StructuredData\Model\Config\Source\ProductAttributes</source_model>
                     <comment><![CDATA[For example GTIN, ISBN, MPN, etc.]]></comment>
                 </field>
+                <field id="brand" sortOrder="20" showInDefault="1" showInStore="1" showInWebsite="1" translate="label" type="select">
+                    <label>Brand</label>
+                    <source_model>Elgentos\StructuredData\Model\Config\Source\ProductAttributes</source_model>
+                </field>
                 <field id="review_limit" sortOrder="30" showInDefault="1" showInStore="1" showInWebsite="1" translate="label comment" type="text">
                     <label>Maximum Number of Reviews to Display</label>
                     <validate>validate-zero-or-greater</validate>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -12,6 +12,7 @@
             <product>
                 <enabled>0</enabled>
                 <gtin/>
+                <brand/>
             </product>
             <breadcrumbs>
                 <enabled>0</enabled>

--- a/tests/Model/Config/Source/ProductAttributesTest.php
+++ b/tests/Model/Config/Source/ProductAttributesTest.php
@@ -21,10 +21,6 @@ use PHPUnit\Framework\TestCase;
  */
 class ProductAttributesTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     * @covers ::toOptionArray
-     */
     public function testToOptionArray(): void
     {
         $collection = $this->createMock(Collection::class);

--- a/tests/ViewModel/Schema/AbstractSchemaTest.php
+++ b/tests/ViewModel/Schema/AbstractSchemaTest.php
@@ -21,9 +21,6 @@ use Elgentos\StructuredData\ViewModel\Schema\AbstractSchema;
 class AbstractSchemaTest extends TestCase
 {
     /**
-     * @covers ::getSerializedData
-     * @covers ::__construct
-     *
      * @dataProvider setStructuredData
      */
     public function testGetSerializedData(

--- a/tests/ViewModel/Schema/BreadcrumbsTest.php
+++ b/tests/ViewModel/Schema/BreadcrumbsTest.php
@@ -23,11 +23,6 @@ use Elgentos\StructuredData\ViewModel\Schema\Breadcrumbs;
 class BreadcrumbsTest extends TestCase
 {
     /**
-     * @covers ::__construct
-     * @covers ::getStructuredData
-     * @covers ::getBreadcrumbItems
-     * @covers ::generateListItem
-     *
      * @dataProvider breadcrumbsDataProvider
      */
     public function testGetStructuredData(

--- a/tests/ViewModel/Schema/OrganizationTest.php
+++ b/tests/ViewModel/Schema/OrganizationTest.php
@@ -23,19 +23,6 @@ class OrganizationTest extends TestCase
 {
     /**
      * @return void
-     *
-     * @covers ::__construct
-     * @covers ::getStructuredData
-     * @covers ::getOrganizationAddress
-     * @covers ::getCompanyName
-     * @covers ::getCompanyEmail
-     * @covers ::getCompanyTelephone
-     * @covers ::getCompanyAddressCity
-     * @covers ::getCompanyAddressRegion
-     * @covers ::getCompanyAddressCountry
-     * @covers ::getCompanyAddressPostalCode
-     * @covers ::getCompanyAddressStreetAddress
-     * @covers ::getWebsiteLogo
      */
     public function testGetStructuredData(): void
     {

--- a/tests/ViewModel/Schema/ProductTest.php
+++ b/tests/ViewModel/Schema/ProductTest.php
@@ -34,10 +34,6 @@ use PHPUnit\Framework\TestCase;
  */
 class ProductTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     * @covers ::isEnabled
-     */
     public function testIsEnabled(): void
     {
         $scopeConfig = $this->createMock(ScopeConfigInterface::class);
@@ -59,17 +55,6 @@ class ProductTest extends TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::getStructuredData
-     * @covers ::getProduct
-     * @covers ::getProductImage
-     * @covers ::getGtinAttribute
-     * @covers ::getProductReviews
-     * @covers ::addReviewEntity
-     * @covers ::calculateRatingValue
-     * @covers ::getAggregateRatingValue
-     * @covers ::getReviewLimit
-     *
      * @dataProvider structuredDataDataProvider
      *
      * @throws NoSuchEntityException
@@ -103,10 +88,11 @@ class ProductTest extends TestCase
         $scopeConfig->expects(self::any())
             ->method('getValue')
             ->withConsecutive(
-                [Product::XML_PATH_GTIN_ATTRIBUTE, ScopeInterface::SCOPE_STORE],
+                [Product::XML_PATH_ATTRIBUTE_GTIN, ScopeInterface::SCOPE_STORE],
+                [Product::XML_PATH_ATTRIBUTE_BRAND, ScopeInterface::SCOPE_STORE],
                 [Product::XML_PATH_REVIEW_LIMIT, ScopeInterface::SCOPE_STORE]
             )
-            ->willReturnOnConsecutiveCalls('foobar', 3);
+            ->willReturnOnConsecutiveCalls('gtin', 'brand', 3);
 
         $subject = new Product(
             $scopeConfig,
@@ -184,8 +170,18 @@ class ProductTest extends TestCase
 
         $productModel->expects(self::any())
             ->method('getData')
-            ->withConsecutive(['description'], ['foobar'], ['rating_summary'])
-            ->willReturnOnConsecutiveCalls('foobar', 'foobar', new DataObject());
+            ->withConsecutive(
+                ['description'],
+                ['gtin'],
+                ['brand'],
+                ['rating_summary']
+            )
+            ->willReturnOnConsecutiveCalls(
+                'description',
+                'gtin',
+                'brand',
+                new DataObject()
+            );
 
         return $productModel;
     }

--- a/tests/ViewModel/Schema/WebsiteTest.php
+++ b/tests/ViewModel/Schema/WebsiteTest.php
@@ -21,11 +21,6 @@ use Elgentos\StructuredData\ViewModel\Schema\Website;
  */
 class WebsiteTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     * @covers ::getStructuredData
-     * @covers ::getPotentialActionData
-     */
     public function testGetStructuredData(): void
     {
         $urlBuilder = $this->createMock(UrlInterface::class);


### PR DESCRIPTION
It's now possible to set the brand for the product using an attribute in
the Magento configuration. If it's left empty, it will not be added as
its an optional parameter in the structured data.